### PR TITLE
extension functionality and spelling number to words

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Import `'package:dartarabic/dartarabic.dart'` and access the static methods in `
 - [normalizeHamzaTasheel](#normalizehamzatasheel)
 - [normalizeAlef](#normalizealef)
 - [normalizeLetters](#normalizeletters)
+- [spellingNumber](#spellingNumber)
 
 ## stripHarakat
 Strip Harakat from arabic word except Shadda.
@@ -28,6 +29,10 @@ The striped marks are :
 Example:
 ```
 print(DartArabic.stripHarakat("الْعَرَبِيّةُ"));
+```
+or
+```
+print("الْعَرَبِيّةُ".stripHarakat());
 ```
 Outputs: `العربيّة`
 
@@ -41,6 +46,10 @@ Strip vowels from a text, include Shadda. The striped marks are :
 Example:
 ```
 print(DartArabic.stripTashkeel("الْعَرَبِيّةُُ"));
+```
+or 
+```
+print("الْعَرَبِيّةُُ".stripTashkeel());
 ```
 Outputs: `العربية`
 
@@ -57,6 +66,10 @@ Example:
 ```
 print(DartArabic.stripDiacritics("الْعَرَبِيّةُُ"));
 ```
+or 
+```
+print("الْعَرَبِيّةُُ".stripDiacritics());
+```
 Outputs: `العربية`
 
 
@@ -65,6 +78,10 @@ Outputs: `العربية`
 Example:
 ```
 print(DartArabic.stripTatweel("العـــــربيةُ"));
+```
+or
+```
+print("العـــــربيةُ".stripTatweel());
 ```
 Outputs: `العربيةُ`
 
@@ -76,6 +93,10 @@ Outputs: `العربيةُ`
 Example:
 ```
 print(DartArabic.stripShadda("الشّمسيّة"));
+```
+or 
+```
+print("الشّمسيّة".stripShadda());
 ```
 Outputs: `الشمسية`
 
@@ -91,6 +112,10 @@ Example:
 ```
 print(DartArabic.normalizeLigature("ﻻنحالي ﻷﻹﻵ"));
 ```
+or 
+```
+print("ﻻنحالي ﻷﻹﻵ".normalizeLigature());
+```
 Outputs: `لانحالي لالالا`
 
 
@@ -100,6 +125,10 @@ Standardize the Hamzat into one form of hamza(uniform method), replace Madda by 
 Example:
 ```
 print(DartArabic.normalizeHamzaUniform("جاء سؤال الأئمة عن الإسلام آجلا"));
+```
+or
+```
+print("جاء سؤال الأئمة عن الإسلام آجلا".normalizeHamzaUniform());
 ```
 Outputs: `جاء سءال الءءمة عن الءسلام ءءجلا`
 
@@ -111,6 +140,10 @@ Example:
 ```
 print(DartArabic.normalizeHamzaTasheel("جاء سؤال الأئمة عن الإسلام آجلا"));
 ```
+or
+```
+print("جاء سؤال الأئمة عن الإسلام آجلا".normalizeHamzaTasheel());
+```
 Outputs: `جاء سوال الايمة عن الاسلام اجلا`
 
 
@@ -121,6 +154,10 @@ Example:
 ```
 print(DartArabic.normalizeAlef("بِٱلْهُدَىٰ"));
 ```
+or
+```
+print("بِٱلْهُدَىٰ".normalizeAlef());
+```
 Outputs: `بِالْهُدَا`
 
 ## normalizeLetters
@@ -130,5 +167,21 @@ Example:
 ```
 print(DartArabic.normalizeLetters("ﻫﻞ"));
 ```
+or 
+```
+print("ﻫﻞ".normalizeLetters());
+```
 Outputs: `هل`
 
+## spellingNumber
+Convert number to ordinal words.
+
+Example:
+```
+print(DartArabic.spellingNumber(1125));
+```
+or
+```
+print(1125.spellingNumber());
+```
+Outputs: `ألف ومائة وخمسة وعشرون`

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -7,32 +7,36 @@ void main() async {
 
   stopwatch.reset();
   stopwatch.start();
-  output = DartArabic.stripHarakat("الْعَرَبِيّةُ");
+  // output = DartArabic.stripHarakat("الْعَرَبِيّةُ");
+  output = "الْعَرَبِيّةُ".stripHarakat();
+
   print("stripHarakat ${stopwatch.elapsedMilliseconds}ms: $output");
 
   stopwatch.reset();
   stopwatch.start();
-  output = DartArabic.stripHarakat("الْعَرَبِيّةُ");
-  print("stripHarakat ${stopwatch.elapsedMilliseconds}ms: $output");
+  //output = DartArabic.stripTashkeel("الْعَرَبِيّةُُ");
+  output = "الْعَرَبِيّةُُ".stripTashkeel();
 
-  stopwatch.reset();
-  stopwatch.start();
-  output = DartArabic.stripTashkeel("الْعَرَبِيّةُُ");
   print("stripTashkeel ${stopwatch.elapsedMilliseconds}ms: $output");
 
   stopwatch.reset();
   stopwatch.start();
-  output = DartArabic.stripShadda("الشّمسيّة");
+  //output = DartArabic.stripShadda("الشّمسيّة");
+  output = "الشّمسيّة".stripShadda();
   print("stripShadda ${stopwatch.elapsedMilliseconds}ms: $output");
 
   stopwatch.reset();
   stopwatch.start();
-  output = DartArabic.normalizeLigature("ﻻنحالي ﻷﻹﻵ");
+  //output = DartArabic.normalizeLigature("ﻻنحالي ﻷﻹﻵ");
+  output = "ﻻنحالي ﻷﻹﻵ".normalizeLigature();
+
   print("normalizeLigature ${stopwatch.elapsedMilliseconds}ms: $output");
 
   stopwatch.reset();
   stopwatch.start();
-  output = DartArabic.normalizeHamzaUniform("جاء سؤال الأئمة عن الإسلام آجلا");
+  //output = DartArabic.normalizeHamzaUniform("جاء سؤال الأئمة عن الإسلام آجلا");
+  output = "جاء سؤال الأئمة عن الإسلام آجلا".normalizeHamzaUniform();
+
   print("normalizeHamzaUniform ${stopwatch.elapsedMilliseconds}ms: $output");
 
   stopwatch.reset();

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -3,69 +3,68 @@ import 'package:dartarabic/dartarabic.dart';
 void main() async {
   String output = "";
   final stopwatch = Stopwatch();
+  int elapsedTime = 0;
   //Use Isolates for heavy computation
 
   stopwatch.reset();
   stopwatch.start();
   // output = DartArabic.stripHarakat("الْعَرَبِيّةُ");
   output = "الْعَرَبِيّةُ".stripHarakat();
+  elapsedTime = stopwatch.elapsedMilliseconds - elapsedTime;
+  print("stripHarakat ${elapsedTime}ms: $output");
 
-  print("stripHarakat ${stopwatch.elapsedMilliseconds}ms: $output");
-
-  stopwatch.reset();
-  stopwatch.start();
   //output = DartArabic.stripTashkeel("الْعَرَبِيّةُُ");
   output = "الْعَرَبِيّةُُ".stripTashkeel();
+  elapsedTime = stopwatch.elapsedMilliseconds - elapsedTime;
+  print("stripTashkeel ${elapsedTime}ms: $output");
 
-  print("stripTashkeel ${stopwatch.elapsedMilliseconds}ms: $output");
-
-  stopwatch.reset();
-  stopwatch.start();
   //output = DartArabic.stripShadda("الشّمسيّة");
   output = "الشّمسيّة".stripShadda();
-  print("stripShadda ${stopwatch.elapsedMilliseconds}ms: $output");
+  elapsedTime = stopwatch.elapsedMilliseconds - elapsedTime;
+  print("stripShadda ${elapsedTime}ms: $output");
 
-  stopwatch.reset();
-  stopwatch.start();
   //output = DartArabic.normalizeLigature("ﻻنحالي ﻷﻹﻵ");
   output = "ﻻنحالي ﻷﻹﻵ".normalizeLigature();
+  elapsedTime = stopwatch.elapsedMilliseconds - elapsedTime;
+  print("normalizeLigature ${elapsedTime}ms: $output");
 
-  print("normalizeLigature ${stopwatch.elapsedMilliseconds}ms: $output");
-
-  stopwatch.reset();
-  stopwatch.start();
   //output = DartArabic.normalizeHamzaUniform("جاء سؤال الأئمة عن الإسلام آجلا");
   output = "جاء سؤال الأئمة عن الإسلام آجلا".normalizeHamzaUniform();
+  elapsedTime = stopwatch.elapsedMilliseconds - elapsedTime;
+  print("normalizeHamzaUniform ${elapsedTime}ms: $output");
 
-  print("normalizeHamzaUniform ${stopwatch.elapsedMilliseconds}ms: $output");
+  //output = DartArabic.normalizeHamzaTasheel("جاء سؤال الأئمة عن الإسلام آجلا");
+  output = "جاء سؤال الأئمة عن الإسلام آجلا".normalizeHamzaTasheel();
+  elapsedTime = stopwatch.elapsedMilliseconds - elapsedTime;
+  print("normalizeHamzaTasheel ${elapsedTime}ms: $output");
 
-  stopwatch.reset();
-  stopwatch.start();
-  output = DartArabic.normalizeHamzaTasheel("جاء سؤال الأئمة عن الإسلام آجلا");
-  print("normalizeHamzaTasheel ${stopwatch.elapsedMilliseconds}ms: $output");
+  //output = DartArabic.normalizeAlef("بِٱلْهُدَىٰ");
+  output = "بِٱلْهُدَىٰ".normalizeAlef();
+  elapsedTime = stopwatch.elapsedMilliseconds - elapsedTime;
+  print("normalizeAlef ${elapsedTime}ms: $output");
 
-  stopwatch.reset();
-  stopwatch.start();
-  output = DartArabic.normalizeAlef("بِٱلْهُدَىٰ");
-  print("normalizeAlef ${stopwatch.elapsedMilliseconds}ms: $output");
+  //output = DartArabic.stripDiacritics("الْعَرَبِيّة");
+  output = "الْعَرَبِيّة".stripDiacritics();
+  elapsedTime = stopwatch.elapsedMilliseconds - elapsedTime;
+  print("stripDiacritics ${elapsedTime}ms: $output");
 
-  stopwatch.reset();
-  stopwatch.start();
-  output = DartArabic.stripDiacritics("الْعَرَبِيّة");
-  print("stripDiacritics ${stopwatch.elapsedMilliseconds}ms: $output");
+  //output = DartArabic.stripDiacritics("الْعَرَبِيّةُ");
+  output = "الْعَرَبِيّةُ".stripDiacritics();
+  elapsedTime = stopwatch.elapsedMilliseconds - elapsedTime;
+  print("stripDiacritics ${elapsedTime}ms: $output");
 
-  stopwatch.reset();
-  stopwatch.start();
-  output = DartArabic.stripDiacritics("الْعَرَبِيّةُ");
-  print("stripDiacritics ${stopwatch.elapsedMilliseconds}ms: $output");
+  //output = DartArabic.stripTatweel("العـــــربيةُ");
+  output = "العـــــربيةُ".stripTatweel();
+  elapsedTime = stopwatch.elapsedMilliseconds - elapsedTime;
+  print("stripTatweel ${elapsedTime}ms: $output");
 
-  stopwatch.reset();
-  stopwatch.start();
-  output = DartArabic.stripTatweel("العـــــربيةُ");
-  print("stripTatweel ${stopwatch.elapsedMilliseconds}ms: $output");
+  //output = DartArabic.normalizeLetters("ﻫﻞ");
+  output = "ﻫﻞ".normalizeLetters();
+  elapsedTime = stopwatch.elapsedMilliseconds - elapsedTime;
+  print("normalizeLetters ${elapsedTime}ms: $output");
 
-  stopwatch.reset();
-  stopwatch.start();
-  output = DartArabic.normalizeLetters("ﻫﻞ");
-  print("normalizeLetters ${stopwatch.elapsedMilliseconds}ms: $output");
+  // output = DartArabic.spellingNumber(1125);
+  output = 1125.spellingNumber();
+  elapsedTime = stopwatch.elapsedMilliseconds - elapsedTime;
+  print("spellingNumber ${elapsedTime}ms: $output");
 }

--- a/lib/dartarabic.dart
+++ b/lib/dartarabic.dart
@@ -2,3 +2,4 @@ library dartarabic;
 
 export 'src/dartarabic.dart';
 export 'src/arabic.dart';
+export 'src/x3orouby.dart';

--- a/lib/src/dartarabic.dart
+++ b/lib/src/dartarabic.dart
@@ -1,3 +1,5 @@
+import 'package:spelling_number/spelling_number.dart';
+
 import 'operations.dart';
 
 abstract class DartArabic {
@@ -32,4 +34,7 @@ abstract class DartArabic {
 
   /// converts non standard letter characters to single letters. e.g HEH_START ﻫ is converted to ه
   static String normalizeLetters(String text) => ArOp.normalize_letters(text);
+
+  /// Convert number to ordinal words
+  static String spellingNumber(num number) => ArOp.spellingNumber(number);
 }

--- a/lib/src/operations.dart
+++ b/lib/src/operations.dart
@@ -1,5 +1,6 @@
 import 'package:dartarabic/src/extensions.dart';
 import 'package:string_validator/string_validator.dart';
+import 'package:spelling_number/spelling_number.dart';
 
 import 'arabic.dart';
 
@@ -165,5 +166,9 @@ class ArOp {
         RegExp(Arabic.ALEF_MAKSURA + Arabic.SMALL_ALEF), Arabic.ALEF_MAKSURA);
     nstring = nstring.replaceAll(Arabic.ALEFAT_PATTERN, Arabic.ALEF);
     return nstring;
+  }
+
+  static String spellingNumber(num number) {
+    return SpellingNumber(lang: 'ar').convert(number);
   }
 }

--- a/lib/src/x3orouby.dart
+++ b/lib/src/x3orouby.dart
@@ -1,0 +1,35 @@
+import 'operations.dart';
+
+extension x3orouby on String {
+  /// Strip Harakat from [text] arabic word except Shadda. The striped marks are : FATHA, DAMMA, KASRA,  FATHATAN, DAMMATAN, KASRATAN,SUKUN Marks,
+  String stripHarakat() => ArOp.strip_harakat(this);
+
+  /// Strip vowels from [text], include Shadda. The striped marks are : FATHA, DAMMA, KASRA, SUKUN, SHADDA, FATHATAN, DAMMATAN, KASRATAN
+  String stripTashkeel() => ArOp.strip_tashkeel(this);
+
+  /// Strip arabic diacritics from [text]. The striped marks are : Small Alef, Harakat + Shadda, Quranic marks, Extended arabic diacritics
+  String stripDiacritics() => ArOp.strip_diacritics(this);
+
+  /// Strip tatweel from [text] and return a result text.
+  String stripTatweel() => ArOp.strip_tatweel(this);
+
+  /// Strip Shadda from [text] and return a result text.
+  String stripShadda() => ArOp.strip_shadda(this);
+
+  /// Normalize Lam Alef ligatures into two letters (LAM and ALEF), and Tand return a result text.Some systems present lamAlef ligature as a single letter, this function convert it into two letters, The converted letters into  LAM and ALEF are  :  LAM_ALEF, LAM_ALEF_HAMZA_ABOVE, LAM_ALEF_HAMZA_BELOW, LAM_ALEF_MADDA_ABOVE
+  String normalizeLigature() => ArOp.normalize_ligature(this);
+
+  /// Standardize the Hamzat into one form of hamza (uniform method), replace Madda by hamza and alef. Replace the LamAlefs by simplified letters.
+  String normalizeHamzaUniform() =>
+      ArOp.normalize_hamza(this, method: ArOp.METHOD_UNIFORM);
+
+  /// Standardize the Hamzat into one form of hamza (Tasheel method), replace Madda by hamza and alef. Replace the LamAlefs by simplified letters.
+  String normalizeHamzaTasheel() =>
+      ArOp.normalize_hamza(this, method: ArOp.METHOD_TASHEEL);
+
+  /// converts all alefs to ALEF_MAMDODA with the exception of Alef maksura
+  String normalizeAlef() => ArOp.normalize_alef(this);
+
+  /// converts non standard letter characters to single letters. e.g HEH_START ﻫ is converted to ه
+  String normalizeLetters() => ArOp.normalize_letters(this);
+}

--- a/lib/src/x3orouby.dart
+++ b/lib/src/x3orouby.dart
@@ -33,3 +33,8 @@ extension x3orouby on String {
   /// converts non standard letter characters to single letters. e.g HEH_START ﻫ is converted to ه
   String normalizeLetters() => ArOp.normalize_letters(this);
 }
+
+extension n3orouby on num {
+  /// Convert number to ordinal words
+  String spellingNumber() => ArOp.spellingNumber(this);
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -42,7 +42,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.1"
   charcode:
     dependency: transitive
     description:
@@ -63,7 +63,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   convert:
     dependency: transitive
     description:
@@ -92,6 +92,11 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "6.1.0"
+  flutter:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   glob:
     dependency: transitive
     description:
@@ -141,13 +146,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.10"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.8.0"
   mime:
     dependency: transitive
     description:
@@ -225,6 +237,11 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
+  sky_engine:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.99"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -246,6 +263,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.1"
+  spelling_number:
+    dependency: "direct main"
+    description:
+      name: spelling_number
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.4"
   stack_trace:
     dependency: transitive
     description:
@@ -316,6 +340,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.2.0-nullsafety.0"
+  vector_math:
+    dependency: transitive
+    description:
+      name: vector_math
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.2"
   vm_service:
     dependency: transitive
     description:
@@ -352,4 +383,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"
+  flutter: ">=1.17.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   string_validator: ^0.3.0
   characters: ^1.1.0-nullsafety.5
   unicode_data: ^0.2.0-nullsafety.0
+  spelling_number: ^0.0.4
 
 dev_dependencies:
   test: ^1.16.4


### PR DESCRIPTION
#### Extension Functionality 
you can now call functions directly form type String, 
example :
```
print("العـــــربيةُ".stripTatweel());
 ```
to get a clean code.
#### Spelling Number to Words
example:
```
print(DartArabic.spellingNumber(1125));
```
Outputs: `ألف ومائة وخمسة وعشرون`
______________________________
Thank you for your support to this beautiful language